### PR TITLE
Fix linting

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -292,7 +292,7 @@ end
 ]=]
 function Trove:AttachToInstance(instance: Instance)
 	assert(instance:IsDescendantOf(game), "Instance is not a descendant of the game hierarchy")
-	return self:Connect(instance.Destroying, function(_child, parent)
+	return self:Connect(instance.Destroying, function()
 		self:Destroy()
 	end)
 end


### PR DESCRIPTION
Removed ``(_child, parent)`` parameters from ``instance.Destroying`` (``Trove:AttachToInstance``)